### PR TITLE
Wiremock random state improvement

### DIFF
--- a/api-gateway/caching-api-response/README.md
+++ b/api-gateway/caching-api-response/README.md
@@ -1,0 +1,31 @@
+[![][license img]][license]
+[![][gitter img]][gitter]
+
+
+# Caching API responses
+
+## Run
+Build and run docker image:
+
+```bash
+$ ./gradlew clean build
+$ docker swarm init
+$ docker stack deploy -c api-cache.yml api-cache
+```
+
+## Endpoints
+
+The application exposes two endpoints:
+
+- `:8092/product/id` - endpoint behind proxy provided by Knot.x
+- `:3000/product/id` - raw endpoint provided by WireMock
+
+The responses contain data that is unique for each and every request to WireMock. By using Knot.x and it's caching mechanisms, we can observe how responses are cached when invoking Knot.x instead of WireMock.
+
+[license]:https://github.com/Cognifide/knotx/blob/master/LICENSE
+[license img]:https://img.shields.io/badge/License-Apache%202.0-blue.svg
+
+[gitter]:https://gitter.im/Knotx/Lobby
+[gitter img]:https://badges.gitter.im/Knotx/knotx-extensions.svg
+
+

--- a/api-gateway/caching-api-response/api-cache.yml
+++ b/api-gateway/caching-api-response/api-cache.yml
@@ -9,7 +9,6 @@ services:
     image: rodolpheche/wiremock
     volumes:
       - "../../common-services/webapi:/home/wiremock"
-      # Remember to put https://repo1.maven.org/maven2/com/opentable/wiremock-body-transformer/1.1.3/wiremock-body-transformer-1.1.3.jar in ../../common-services/webapi/extensions directory!
       - "../../common-services/webapi/extensions:/var/wiremock/extensions"
     ports:
       - "3000:8080"

--- a/api-gateway/caching-api-response/api-cache.yml
+++ b/api-gateway/caching-api-response/api-cache.yml
@@ -9,10 +9,13 @@ services:
     image: rodolpheche/wiremock
     volumes:
       - "../../common-services/webapi:/home/wiremock"
+      # Remember to put https://repo1.maven.org/maven2/com/opentable/wiremock-body-transformer/1.1.3/wiremock-body-transformer-1.1.3.jar in ../../common-services/webapi/extensions directory!
+      - "../../common-services/webapi/extensions:/var/wiremock/extensions"
     ports:
       - "3000:8080"
     networks:
       - knotnet
+    command: ["--global-response-templating", "--extensions", "com.opentable.extension.BodyTransformer"]
 
   knotx:
     image: knotx-example/api-cache:latest

--- a/api-gateway/caching-api-response/build.gradle.kts
+++ b/api-gateway/caching-api-response/build.gradle.kts
@@ -19,8 +19,13 @@ plugins {
     id("java")
 }
 
+configurations {
+    register("wiremockExtensions")
+}
+
 dependencies {
     subprojects.forEach { "dist"(project(":${it.name}")) }
+    "wiremockExtensions"("com.opentable:wiremock-body-transformer:1.1.3") { isTransitive = false }
 }
 
 sourceSets.named("test") {
@@ -39,8 +44,13 @@ allprojects {
     }
 }
 
+val downloadWireMockExtensions = tasks.register<Copy>("downloadWiremockExtensions") {
+    from(configurations.named("wiremockExtensions"))
+    into("../../common-services/webapi/extensions")
+}
+
 tasks.named("build") {
-    dependsOn("runFunctionalTest")
+    dependsOn(downloadWireMockExtensions, "runFunctionalTest")
 }
 
 apply(from = "https://raw.githubusercontent.com/Knotx/knotx-starter-kit/master/gradle/docker.gradle.kts")

--- a/api-gateway/caching-api-response/knotx/conf/routes/handlers/fragments-handler.conf
+++ b/api-gateway/caching-api-response/knotx/conf/routes/handlers/fragments-handler.conf
@@ -44,7 +44,7 @@ actions {
     # https://github.com/Knotx/knotx-fragments/blob/2.0.0/handler/core/src/main/java/io/knotx/fragments/handler/action/PayloadToBodyActionFactory.java
     factory = payload-to-body
     config {
-      key = fetch-product
+      key = "fetch-product._result"
     }
   }
 }

--- a/common-services/webapi/__files/product.json
+++ b/common-services/webapi/__files/product.json
@@ -1,5 +1,7 @@
 {
   "id": 21762532,
   "url": "http://knotx.io",
-  "label": "Product"
+  "label": "Product",
+  "currentTime": "{{now format='yyyy-MM-dd HH:mm:ss'}}",
+  "promoCode": "{{randomValue length=6 type='ALPHANUMERIC'}}"
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Wiremock responses now return random state with each request.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
It's easier to demonstrate caching behaviour if the external API is returning different response with each request.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the [code style](/CONTRIBUTING.md#coding-conventions) of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

---
I hereby agree to the terms of the Knot.x Contributor License Agreement.
